### PR TITLE
update rate limits to 100/sec and 200/min, improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RateLimiter (C# + Docker)
 
-A custom, thread-safe rate limiter implemented in C# using the **sliding window** algorithm. It supports **multiple simultaneous rate limits** (e.g., 10/sec, 100/min, 1000/day) and guarantees all limits are honored — even when accessed from multiple threads.
+A custom, thread-safe rate limiter implemented in C# using the **sliding window** algorithm. It supports **multiple simultaneous rate limits** (e.g., 100/sec, 200/min) and guarantees all limits are honored — even when accessed from multiple threads.
 
 ---
 


### PR DESCRIPTION
Rate Limiter Behavior
Updated rate limits to:

100 requests per second

200 requests per minute

Implemented improved handling of concurrency with SemaphoreSlim.

Ensures minimal delay where possible — multiple requests within limits are now executed immediately (instead of unnecessarily queued).

Demo Enhancements
Increased the number of simulated calls in the demo to stress-test the limiter under realistic concurrent load.

Refactored log messages for clarity, using the coffee analogy to explain rate enforcement.